### PR TITLE
Add support for re2

### DIFF
--- a/base.go
+++ b/base.go
@@ -40,7 +40,7 @@ func (h Host) Must(name, expr string) {
 // NewBase creates new Host that filled up with base patterns.
 // To see all base patterns open 'base.go' file.
 func NewBase() Host {
-	h := make(Host)
+	h := Host{Patterns: make(map[string]string)}
 	//
 	h.Must("USERNAME", `[a-zA-Z0-9._-]+`)
 	h.Must("USER", `%{USERNAME}`)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/crowdsecurity/grokky
+
+go 1.20
+
+require (
+	github.com/vjeantet/grok v1.0.1
+	github.com/wasilibs/go-re2 v0.1.0
+)
+
+require (
+	github.com/magefile/mage v1.14.0 // indirect
+	github.com/tetratelabs/wazero v1.0.0-pre.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
+github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/tetratelabs/wazero v1.0.0-pre.5 h1:ChZsQewsazFwF+NT6qAKPwnqqiOlf2MN0aah1dlD8Bk=
+github.com/tetratelabs/wazero v1.0.0-pre.5/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/vjeantet/grok v1.0.1 h1:2rhIR7J4gThTgcZ1m2JY4TrJZNgjn985U28kT2wQrJ4=
+github.com/vjeantet/grok v1.0.1/go.mod h1:ax1aAchzC6/QMXMcyzHQGZWaW1l195+uMYIkCWPCNIo=
+github.com/wasilibs/go-re2 v0.1.0 h1:+pcjlvge6E9WWU4eaMlULRikEUkhPDXSFfCF5p7htMI=
+github.com/wasilibs/go-re2 v0.1.0/go.mod h1:F91Yac+zPNDFrrd8fl4mSd7+TTu2tYiX56BEIEPQl2M=

--- a/host_test.go
+++ b/host_test.go
@@ -41,57 +41,54 @@ const (
 
 func TestNew(t *testing.T) {
 	h := New()
-	if len(h) != 0 {
+	if len(h.Patterns) != 0 {
 		t.Error("New returns non-empty host")
-	}
-	if h == nil {
-		t.Error("New returns nil")
 	}
 }
 
 func testEmptyName(t *testing.T, h Host) {
-	l := len(h)
+	l := len(h.Patterns)
 	if err := h.Add("", "expr"); err == nil {
 		t.Error("(Host).Add is missing ErrEmptyName")
 	} else if err != ErrEmptyName {
 		t.Error("(Host).Add returns non-ErrEmptyName error")
 	}
-	if len(h) > l {
+	if len(h.Patterns) > l {
 		t.Error("added bad patterns")
 	}
 }
 
 func testEmptyExpression(t *testing.T, h Host) {
-	l := len(h)
+	l := len(h.Patterns)
 	if err := h.Add("zorro", ""); err == nil {
 		t.Error("(Host).Add is missing ErrEmptyExpression")
 	} else if err != ErrEmptyExpression {
 		t.Error("(Host).Add returns non-ErrEmptyExpression error")
 	}
-	if len(h) > l {
+	if len(h.Patterns) > l {
 		t.Error("added bad patterns")
 	}
 }
 
 func testNormalPattern(t *testing.T, h Host) {
-	l := len(h)
+	l := len(h.Patterns)
 	if err := h.Add("DIGIT", `\d`); err != nil {
 		t.Errorf("(Host).Add returns non-nil error: %v", err)
 	}
-	if len(h) != l+1 {
+	if len(h.Patterns) != l+1 {
 		t.Error("wrong patterns count")
 	}
 }
 
 // must be invoked direct after testNormalPattern
 func testAlreadyExists(t *testing.T, h Host) {
-	l := len(h)
+	l := len(h.Patterns)
 	if err := h.Add("DIGIT", `[+-](0x)?\d`); err == nil {
 		t.Error("(Host).Add is missing ErrAlreadyExist")
 	} else if err != ErrAlreadyExist {
 		t.Error("(Host).Add returns non-ErrAlreadyExist error")
 	}
-	if len(h) != l {
+	if len(h.Patterns) != l {
 		t.Error("wrong patterns count")
 	}
 }
@@ -105,37 +102,37 @@ func TestHost_Add(t *testing.T) {
 	if err := h.Add("BAD", `(?![0-5])`); err == nil {
 		t.Error("(Host).Add is missing any bad-regexp error")
 	}
-	if len(h) != 1 {
+	if len(h.Patterns) != 1 {
 		t.Error("wrong patterns count")
 	}
 	if err := h.Add("TWODIG", `%{DIGIT}-%{DIGIT}`); err != nil {
 		t.Errorf("(Host).Add returns non-nil error: %v", err)
 	}
-	if len(h) != 2 {
+	if len(h.Patterns) != 2 {
 		t.Error("wrong patterns count")
 	}
 	if err := h.Add("THREE", `%{NOT}-%{EXIST}`); err == nil {
 		t.Errorf("(Host).Add is missing the-pattern-not-exist error")
 	}
-	if len(h) != 2 {
+	if len(h.Patterns) != 2 {
 		t.Error("wrong patterns count")
 	}
 	if err := h.Add("FOUR", `%{DIGIT:one}-%{DIGIT:two}`); err != nil {
 		t.Errorf("(Host).Add returns non-nil error: %v", err)
 	}
-	if len(h) != 3 {
+	if len(h.Patterns) != 3 {
 		t.Error("wrong patterns count")
 	}
 	if err := h.Add("FIVE", `(?!\d)%{DIGIT}(?!\d)`); err == nil {
 		t.Errorf("(Host).Add is missing an error of regexp")
 	}
-	if len(h) != 3 {
+	if len(h.Patterns) != 3 {
 		t.Error("wrong patterns count")
 	}
 	if err := h.Add("SIX", `%{FOUR:four}-%{DIGIT:six}`); err != nil {
 		t.Errorf("(Host).Add returns non-nil error")
 	}
-	if len(h) != 4 {
+	if len(h.Patterns) != 4 {
 		t.Error("wrong patterns count")
 	}
 }
@@ -147,7 +144,7 @@ func TestHost_Compile(t *testing.T) {
 	} else if err != ErrEmptyExpression {
 		t.Error("(Host).Compile returns non-ErrEmptyExpression error")
 	}
-	if len(h) != 0 {
+	if len(h.Patterns) != 0 {
 		t.Error("(Host).Compile: (bad) pattern added to host")
 	}
 	if p, err := h.Compile(`\d+`); err != nil {
@@ -155,7 +152,7 @@ func TestHost_Compile(t *testing.T) {
 	} else if p == nil {
 		t.Error("(Host).Compile returns nil (and no errors)")
 	}
-	if len(h) != 0 {
+	if len(h.Patterns) != 0 {
 		t.Error("(Host).Compile: pattern added to host")
 	}
 }
@@ -196,7 +193,7 @@ func TestHost_AddFromFile(t *testing.T) {
 	if err := h.AddFromFile(patternsTest); err != nil {
 		t.Error(err)
 	}
-	if len(h) != 3 {
+	if len(h.Patterns) != 3 {
 		t.Error("wrong patterns count")
 	}
 	if _, err := h.Get("ONE"); err != nil {
@@ -229,7 +226,7 @@ func TestHost_AddFromFile_scannerError(t *testing.T) {
 
 func TestHost_inject(t *testing.T) {
 	h := New()
-	h["TWO"] = `(?!\d)`
+	h.Patterns["TWO"] = `(?!\d)`
 	if err := h.Add("ONE", `%{TWO:one}`); err == nil {
 		t.Error("bad injection returns nil error")
 	}

--- a/pattern.go
+++ b/pattern.go
@@ -1,0 +1,9 @@
+package grokky
+
+type Pattern interface {
+	FindStringSubmatch(s string) []string
+	String() string
+	Names() []string
+	Parse(input string) map[string]string
+	NumSubexp() int
+}

--- a/pattern_legacy.go
+++ b/pattern_legacy.go
@@ -1,0 +1,32 @@
+package grokky
+
+import "regexp"
+
+// Pattern is a pattern.
+// Feel free to use the Pattern as regexp.Regexp.
+type PatternLegacy struct {
+	*regexp.Regexp
+	s map[string]int
+}
+
+// Parse returns map (name->match) on input. The map can be empty.
+func (p *PatternLegacy) Parse(input string) map[string]string {
+	ss := p.FindStringSubmatch(input)
+	r := make(map[string]string)
+	if len(ss) <= 1 {
+		return r
+	}
+	for sem, order := range p.s {
+		r[sem] = ss[order]
+	}
+	return r
+}
+
+// Names returns all names that this pattern has
+func (p *PatternLegacy) Names() (ss []string) {
+	ss = make([]string, 0, len(p.s))
+	for k := range p.s {
+		ss = append(ss, k)
+	}
+	return
+}

--- a/pattern_re2.go
+++ b/pattern_re2.go
@@ -1,0 +1,34 @@
+package grokky
+
+import (
+	"github.com/wasilibs/go-re2"
+)
+
+// Pattern is a pattern.
+// Feel free to use the Pattern as regexp.Regexp.
+type PatternRe2 struct {
+	*re2.Regexp
+	s map[string]int
+}
+
+// Parse returns map (name->match) on input. The map can be empty.
+func (p *PatternRe2) Parse(input string) map[string]string {
+	ss := p.FindStringSubmatch(input)
+	r := make(map[string]string)
+	if len(ss) <= 1 {
+		return r
+	}
+	for sem, order := range p.s {
+		r[sem] = ss[order]
+	}
+	return r
+}
+
+// Names returns all names that this pattern has
+func (p *PatternRe2) Names() (ss []string) {
+	ss = make([]string, 0, len(p.s))
+	for k := range p.s {
+		ss = append(ss, k)
+	}
+	return
+}

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,37 @@
+package grokky
+
+import (
+	"regexp"
+	"strings"
+)
+
+// helpers
+
+func split(s string) (name, sem string) {
+	ss := patternRegexp.FindStringSubmatch(s)
+	if len(ss) >= 2 {
+		name = ss[1]
+	}
+	if len(ss) >= 4 {
+		sem = ss[3]
+	}
+	return
+}
+
+func wrap(s string) string { return "(" + s + ")" }
+
+// http://play.golang.org/p/1rPuziYhRL
+
+var (
+	nonCapLeftRxp  = regexp.MustCompile(`\(\?[imsU\-]*\:`)
+	nonCapFlagsRxp = regexp.MustCompile(`\(?[imsU\-]+\)`)
+)
+
+// cap count
+func capCount(in string) int {
+	leftParens := strings.Count(in, "(")
+	nonCapLeft := len(nonCapLeftRxp.FindAllString(in, -1))
+	nonCapBoth := len(nonCapFlagsRxp.FindAllString(in, -1))
+	escapedLeftParens := strings.Count(in, `\(`)
+	return leftParens - nonCapLeft - nonCapBoth - escapedLeftParens
+}


### PR DESCRIPTION
This PR adds support for the [re2](https://github.com/google/re2) regexp library to grokky, which is much faster than the stdlib regexp package.

By default, we still use the stdlib regexp module, but setting `UseRe2` to `true` in the `Host` struct will make grokky use re2.